### PR TITLE
Add SysUpTime to generated SNMP Trap

### DIFF
--- a/snmptrapper/send_trap.go
+++ b/snmptrapper/send_trap.go
@@ -28,6 +28,10 @@ func sendTrap(alert types.Alert) {
 	// Build VarBind list:
 	var varBinds snmpgo.VarBinds
 
+	// Insert SysUpTime
+	secs := uint32(time.Now().Unix())
+	varBinds = append(varBinds, snmpgo.NewVarBind(snmpgo.OidSysUpTime, snmpgo.NewTimeTicks(secs)))
+
 	// The "enterprise OID" for the trap (rising/firing or falling/recovery):
 	if alert.Status == "firing" {
 		varBinds = append(varBinds, snmpgo.NewVarBind(snmpgo.OidSnmpTrap, trapOIDs.FiringTrap))


### PR DESCRIPTION
According to RFC, the SNMP Trap should contain `sysUpTime` as the first `varbin`.